### PR TITLE
Instruction fixes

### DIFF
--- a/src/app/components/console/console.component.ts
+++ b/src/app/components/console/console.component.ts
@@ -123,7 +123,7 @@ export class ConsoleComponent implements OnInit {
 
     // lights
     this.drawLightRowCol(407, 296, this.pdp.PC, 16, true);
-    this.drawLightRowCol(407, 454, this.pdp.PC, 16, true);
+    this.drawLightRowCol(407, 454, this.pdp.MA, 16, true);
     this.drawLightRowCol(249, 612, this.pdp.MB, 18, true);
     this.drawLightRowCol(249, 770, this.pdp.AC, 18, true);
     this.drawLightRowCol(249, 928, this.pdp.IO, 18, true);


### PR DESCRIPTION
I ran MAINDEC instruction test and tried to fix the instructions.

Note that this doesn't test MUS/DIS/MUL/DIV. There's a test program for those, but it requires typewriter output. I can probably fake typewriter output if needed to run those tests though.

Memory Address display (I'm not sure if it's necessary. I was very confused at MA not matching up until I saw it was coded as PC. But possible at the instruction level it might be just PC-1?)

Instruction fixes:
* Unknown instructions halt
* shift left preserves sign bit and puts sign bit into lowest value bit.
* Indexing instructions obey end-around-carry